### PR TITLE
Change nickname creation to use name instead of vat

### DIFF
--- a/app/commands/decidim/odoo/sync_user.rb
+++ b/app/commands/decidim/odoo/sync_user.rb
@@ -44,7 +44,7 @@ module Decidim
       end
 
       def update_user!
-        user.nickname = Decidim::UserBaseEntity.nicknamize(odoo_info[:vat], organization: user.organization) if odoo_info[:vat].present?
+        user.nickname = Decidim::UserBaseEntity.nicknamize(odoo_info[:name], organization: user.organization) if odoo_info[:name].present?
         user.name = odoo_info[:name] if odoo_info[:name].present?
         user.extended_data.merge!(
           "odoo_info" => {

--- a/lib/omniauth/strategies/odoo_keycloak.rb
+++ b/lib/omniauth/strategies/odoo_keycloak.rb
@@ -11,7 +11,7 @@ module OmniAuth
 
       info do
         {
-          nickname: odoo_info[:vat].presence || raw_info["preferred_username"],
+          nickname: odoo_info[:name].presence || raw_info["preferred_username"],
           name: odoo_info[:name].presence || raw_info["name"],
           email: odoo_info[:email].presence || raw_info["email"]
         }

--- a/spec/omni_auth/strategies/odoo_keycloak_spec.rb
+++ b/spec/omni_auth/strategies/odoo_keycloak_spec.rb
@@ -62,7 +62,7 @@ describe OmniAuth::Strategies::OdooKeycloak do
     end
 
     it "returns the nickname" do
-      expect(subject.info[:nickname]).to eq(vat)
+      expect(subject.info[:nickname]).to eq(name)
     end
 
     it "returns the email" do


### PR DESCRIPTION
In https://github.com/Platoniq/decidim-module-odoo/pull/10 the use of `vat` as nickname was added. This PR changes it so that it uses the user name instead.

It also includes a Rake task to update older users with the new nickname.